### PR TITLE
Use scriptcontext for tol instead of active doc

### DIFF
--- a/src/wasp/__init__.py
+++ b/src/wasp/__init__.py
@@ -34,10 +34,10 @@ from __future__ import division
 import os
 import sys
 
-from Rhino.RhinoDoc import ActiveDoc
+import scriptcontext
 
 
-global_tolerance = ActiveDoc.ModelAbsoluteTolerance*2
+global_tolerance = scriptcontext.doc.ModelAbsoluteTolerance*2
 
 
 __author__ = ['ar0551 <a.rossi.andrea@gmail.com>']


### PR DESCRIPTION
Hey @ar0551, I ran into this one recently while experimenting with installing Wasp on a machine running [Rhino Compute](http://github.com/mcneel/compute.rhino3d).

`ActiveDoc` will be null when Rhino is running in "headless" mode (as it does when running in Rhino Compute). To workaround this you can use `scriptcontext.doc` which defines default values for tolerances and units when no active document exists.