### PR TITLE
Tiny hotfix to make support constraints work in Rhino 8

### DIFF
--- a/src/wasp/__init__.py
+++ b/src/wasp/__init__.py
@@ -39,7 +39,7 @@ from Rhino import RhinoApp
 
 
 global_tolerance = scriptcontext.doc.ModelAbsoluteTolerance*2
-is_rh7 = True if RhinoApp.ExeVersion == 7 else False
+is_rh7 = True if RhinoApp.ExeVersion >= 7 else False
 
 
 __author__ = ['ar0551 <a.rossi.andrea@gmail.com>']


### PR DESCRIPTION
When using support constraints in Rhino 8 in local constraint mode, the aggregation component throws an `IndexError`.

This happens during a `check_intersection_w_line` call in `colliders.py`. The function checks the `is_rh7` constant, which returns False when running in Rhino 8.

I know this is probably not an optimal solution, but the quickest and easiest way to make it work in Rhino 8.